### PR TITLE
[ci skip] adding user @stefaniesmith

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dvreed77 @gsheni @jeff-hernandez @machineAYX @ozzieD @rwedge @sbadithe @tamargrey @thehomebrewnerd
+* @stefaniesmith @dvreed77 @gsheni @jeff-hernandez @machineAYX @ozzieD @rwedge @sbadithe @tamargrey @thehomebrewnerd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,6 +73,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - stefaniesmith
     - sbadithe
     - ozzieD
     - machineAYX


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @stefaniesmith as instructed in #119.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #119